### PR TITLE
fix: remove horizontal overflow

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -23,7 +23,7 @@ const { title, description } = Astro.props;
 <!doctype html>
 <html lang="es">
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width" />
   <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
   <title>{title}</title>
 


### PR DESCRIPTION
### Por favor, comprueba si el PR cumple estos requisitos

- [x] El mensaje del commit sigue nuestras directrices
- [x] Se han añadido pruebas para los cambios (para correcciones de errores / características)
- [ ] Se han añadido / actualizado documentos (para correcciones de errores / características)


### ¿Qué tipo de cambio introduce este PR?
Fix.

### ¿Cuál es el comportamiento actual?
Existe un overflow horizontal, esto es provocado por el valor `initial-scale=1` de la etiqueta meta viewport.

### ¿Cuál es el nuevo comportamiento?
Se elimina el valor `initial-scale=1` para evitar el overflow horizontal. Soluciona el issue #71.

### ¿Este PR introduce un breaking change?
No :p

**Otra información**:

https://github.com/user-attachments/assets/6e016e4c-45d6-4ed9-b243-a358df840da2





