### PR TITLE
fix: :sparkles: add opacity to hero caption image

### DIFF
--- a/apps/jsconf/src/components/DateInfoHome.astro
+++ b/apps/jsconf/src/components/DateInfoHome.astro
@@ -60,6 +60,7 @@ const { left, right, filled = false, position } = Astro.props;
     &.fourth {
       inset-inline-end: -8%;
       inset-block-start: -3%;
+      opacity: 0.25;
     }
   }
 

--- a/apps/jsconf/src/sections/Hero.astro
+++ b/apps/jsconf/src/sections/Hero.astro
@@ -147,6 +147,7 @@ import { Button, DateInfoHome, RadiusGradientFrame } from '@components';
           font-family: monospace;
           position: absolute;
           bottom: 0;
+          opacity: 0.25;
 
           & span {
             color: var(--yellow);


### PR DESCRIPTION
### Por favor, comprueba si el PR cumple estos requisitos

- [x] El mensaje del commit sigue nuestras directrices
- [ ] Se han añadido pruebas para los cambios (para correcciones de errores / características)
- [ ] Se han añadido / actualizado documentos (para correcciones de errores / características)


### ¿Qué tipo de cambio introduce este PR?
update

### ¿Cuál es el comportamiento actual?
La gente se confundía con la localiadad del evento porque en el hero aparecía el caption indicando que la imagen hace referencia a las torres del paine y por ende asumían que el evento sería en el sur de Chile.

### ¿Cuál es el nuevo comportamiento?
Se agrega una opacidad al texto para que no llame la atención pero que de igual manera siga apareciendo para que las personas que no sepan a qué hace referencia la imagen tenga disponible esa información.

### ¿Este PR introduce un breaking change?
Nop

